### PR TITLE
Add Copilot path-specific custom instructions with applyTo frontmatter

### DIFF
--- a/.github/copilot-instructions/pageobjects.instructions.md
+++ b/.github/copilot-instructions/pageobjects.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "src/main/java/com/nichethyself/pageobjects/**/*.java"
+---
+
+# Copilot Custom Instructions: Page Objects
+
+- Place all Page Object Model (POM) classes for web pages and reusable components in the `src/main/java/com/nichethyself/pageobjects/` directory.
+- Each class should represent a single page or a significant UI component (e.g., `LoginPage`, `HomePage`).
+- Use `@FindBy` annotations for element locators and initialize with `PageFactory`.
+- Encapsulate all page interactions as public methods (e.g., `login()`, `search()`).
+- Keep locators private and expose only business actions.
+- Do not include test logic or assertions in page objects.
+- Example file names: `LoginPage.java`, `HomePage.java`, `ContactUsPage.java`.

--- a/.github/copilot-instructions/tests.instructions.md
+++ b/.github/copilot-instructions/tests.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "src/test/java/com/nichethyself/tests/**/*.java"
+---
+
+# Copilot Custom Instructions: Test Classes
+
+- Place all UI and API test classes in the `src/test/java/com/nichethyself/tests/` directory (and subfolders for organization).
+- Each test class should focus on a single feature or end-to-end scenario (e.g., `LoginTest`, `EndToEndScenariosTest`).
+- Use TestNG annotations (`@Test`, `@BeforeMethod`, `@AfterMethod`) for test structure.
+- Import and use page objects for all UI interactions.
+- Keep tests independent and stateless where possible.
+- Use assertions to validate outcomes.
+- Do not put page locators or business logic in test classes.
+- Example file names: `LoginTest.java`, `ContactUsTest.java`.

--- a/.github/copilot-instructions/utilities.instructions.md
+++ b/.github/copilot-instructions/utilities.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "src/main/java/com/nichethyself/utilities/**/*.java"
+---
+
+# Copilot Custom Instructions: Utilities
+
+- Place all utility/helper classes in the `src/main/java/com/nichethyself/utilities/` directory (e.g., WebDriver utilities, data providers, config readers).
+- Utilities should be generic and reusable across tests and page objects.
+- Do not include test logic or page-specific code here.
+- Example file names: `TestDataUtil.java`, `ConfigReader.java`, `WaitUtils.java`.
+- Document utility methods for clarity and maintainability.


### PR DESCRIPTION
### Summary
This pull request adds path-specific Copilot custom instruction files to `.github/copilot-instructions/` for improved AI guidance and compliance with the latest GitHub Copilot documentation. Each file now includes the required YAML frontmatter with the `applyTo` glob pattern, ensuring Copilot applies the correct instructions to:

- Page Object Model classes (`pageobjects.instructions.md`)
- Test classes (`tests.instructions.md`)
- Utility/helper classes (`utilities.instructions.md`)

### Details
- Each instruction file starts with a YAML frontmatter block specifying the `applyTo` path for relevant Java files.
- Instructions are clear, concise, and follow best practices for maintainable automation code.
- This update ensures full compatibility with Copilot coding agent and code review features.

**Please review and merge to enable enhanced Copilot support and compliance.**