### PR TITLE
Add Copilot custom instructions for reports module

### DIFF
--- a/.github/copilot-instructions/reports.instructions.md
+++ b/.github/copilot-instructions/reports.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "src/main/java/com/nichethyself/reports/**/*.java"
+---
+
+# Copilot Custom Instructions: Reports
+
+- Place all reporting-related classes in the `src/main/java/com/nichethyself/reports/` directory.
+- Use clear, descriptive class and method names for report generation, formatting, and export (e.g., `ReportManager`, `HtmlReportGenerator`).
+- Ensure reports are generated in standard formats (HTML, PDF, XML, etc.) as required by the project.
+- Separate report configuration, data collection, and rendering logic for maintainability.
+- Document any third-party libraries or frameworks used for reporting (e.g., ExtentReports, Allure).
+- Provide utility methods for attaching screenshots, logs, and test metadata to reports.
+- Avoid hardcoding file paths; use configuration files or environment variables.
+- Ensure thread safety if reports are generated in parallel test execution.
+- Follow the same code quality and documentation standards as the rest of the project.


### PR DESCRIPTION
### Summary
This pull request adds a path-specific Copilot custom instruction file for the reports module in `.github/copilot-instructions/reports.instructions.md`.

### Details
- Includes YAML frontmatter with the correct `applyTo` glob pattern for report-related Java files
- Provides best practices and guidance for generating, formatting, and maintaining test reports
- Follows the same compliance and structure as other Copilot instruction files in the repository

This will help ensure Copilot provides accurate and context-aware suggestions for all reporting code.